### PR TITLE
Option to use singularity instead of docker

### DIFF
--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -8,15 +8,19 @@
 # The assumption is that you are working in the src/ontology folder;
 # we therefore map the whole repo (../..) to a docker volume.
 #
-# To use singularity instead of docker, please issue
-# 
+# To use singularity instead of docker, please issue 
 # export USE_SINGULARITY=<any-value>
-#
 # before running this script.
 #
 # See README-editors.md for more details.
 
 IMAGE=${IMAGE:-odkfull}
+TAG_IN_IMAGE=$(echo $IMAGE | awk -F':' '{ print $2 }')
+if [ "$TAG_IN_IMAGE" ]; then
+  # Override TAG env var if IMAGE already includes a tag
+  TAG=$TAG_IN_IMAGE
+  IMAGE=$(echo $IMAGE | awk -F':' '{ print $1 }')
+fi
 TAG=${TAG:-latest}
 ODK_JAVA_OPTS=-Xmx10G
 ODK_DEBUG=${ODK_DEBUG:-no}
@@ -26,7 +30,7 @@ if [ x$ODK_DEBUG = xyes ]; then
     # If you wish to change the format string, take care of using
     # non-breaking spaces (U+00A0) instead of normal spaces, to
     # prevent the shell from tokenizing the format string.
-    echo "Running ${IMAGE} with ${ODK_JAVA_OPTS} of memory for ROBOT and Java-based pipeline steps."
+    echo "Running ${IMAGE}:${TAG} with ${ODK_JAVA_OPTS} of memory for ROBOT and Java-based pipeline steps."
     TIMECMD="/usr/bin/time -f ### DEBUG STATS ###\nElapsed time: %E\nPeak memory: %M kb"
 fi
 
@@ -35,9 +39,7 @@ VOLUME_BIND=$PWD/../../:/work
 WORK_DIR=/work/src/ontology
 
 if [ -n "$USE_SINGULARITY" ]; then
-    export ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS"
-    export JAVA_OPTS="$ODK_JAVA_OPTS"
-    singularity exec --bind $VOLUME_BIND -W $WORK_DIR docker://obolibrary/$IMAGE:$TAG $TIMECMD "$@"
+    singularity exec --cleanenv --env "ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS,JAVA_OPTS=$ODK_JAVA_OPTS" --bind $VOLUME_BIND -W $WORK_DIR docker://obolibrary/$IMAGE:$TAG $TIMECMD "$@"
 else
     docker run -v $VOLUME_BIND -w $WORK_DIR -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" --rm -ti obolibrary/$IMAGE:$TAG $TIMECMD "$@"
 fi

--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -37,7 +37,7 @@ WORK_DIR=/work/src/ontology
 if [ -n "$USE_SINGULARITY" ]; then
     export ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS"
     export JAVA_OPTS="$ODK_JAVA_OPTS"
-    singularity exec --bind $VOLUME_BIND -W $WORK_DIR docker://$IMAGE:$TAG $TIMECMD "$@"
+    singularity exec --bind $VOLUME_BIND -W $WORK_DIR docker://obolibrary/$IMAGE:$TAG $TIMECMD "$@"
 else
     docker run -v $VOLUME_BIND -w $WORK_DIR -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" --rm -ti obolibrary/$IMAGE:$TAG $TIMECMD "$@"
 fi


### PR DESCRIPTION
This PR adds some options picked form the environment for run.sh to be able to rely on Singularity instead of docker optionally. This is for our generation of the scatlas ontology on the cluster.